### PR TITLE
Changes to enable Windows build

### DIFF
--- a/src/Magnum/SceneGraph/Python.h
+++ b/src/Magnum/SceneGraph/Python.h
@@ -62,22 +62,22 @@ template<class T> struct PyFeatureHolder: std::unique_ptr<T> {
 
 /* Hey this needs docs. */
 
-template<class Object> class PyObject: public Object {
+template<class Obj> class PyObject: public Obj {
     public:
-        template<class ...Args> explicit PyObject(Args&&... args): Object{std::forward<Args>(args)...} {}
+        template<class ...Args> explicit PyObject(Args&&... args): Obj{std::forward<Args>(args)...} {}
 
-        PyObject(const PyObject<Object>&) = delete;
-        PyObject(PyObject<Object>&&) = delete;
+        PyObject(const PyObject<Obj>&) = delete;
+        PyObject(PyObject<Obj>&&) = delete;
 
-        PyObject<Object>& operator=(const PyObject<Object>&) = delete;
-        PyObject<Object>& operator=(PyObject<Object>&&) = delete;
+        PyObject<Obj>& operator=(const PyObject<Obj>&) = delete;
+        PyObject<Obj>& operator=(PyObject<Obj>&&) = delete;
 
     private:
         void doErase() override {
             /* When deleting a parent, disconnect this from the parent instead
                of deleting it. Deletion is then handled by Python itself. */
-            CORRADE_INTERNAL_ASSERT(Object::parent());
-            Object::setParent(nullptr);
+            CORRADE_INTERNAL_ASSERT(Obj::parent());
+            Obj::setParent(nullptr);
             pybind11::cast(this).dec_ref();
         }
 };

--- a/src/python/magnum/magnum.cpp
+++ b/src/python/magnum/magnum.cpp
@@ -216,7 +216,9 @@ void magnum(py::module& m) {
 
 /* TODO: remove declaration when https://github.com/pybind/pybind11/pull/1863
    is released */
+#ifndef CORRADE_TARGET_WINDOWS
 extern "C" PyObject* PyInit__magnum();
+#endif
 PYBIND11_MODULE(_magnum, m) {
     /* We need ArrayView for images */
     py::module::import("corrade.containers");

--- a/src/python/magnum/platform/glfw.cpp
+++ b/src/python/magnum/platform/glfw.cpp
@@ -41,7 +41,7 @@ void glfw(py::module& m) {
     struct PublicizedApplication: Platform::Application {
         explicit PublicizedApplication(const Configuration& configuration, const GLConfiguration& glConfiguration): Platform::Application{Arguments{argc, nullptr}, configuration, glConfiguration} {}
 
-        void drawEvent() override = 0;
+        void drawEvent() override {}
         void mousePressEvent(MouseEvent&) override {}
         void mouseReleaseEvent(MouseEvent&) override {}
         void mouseMoveEvent(MouseMoveEvent&) override {}


### PR DESCRIPTION
**changes to Python.h fixes:**
magnum-bindings\src\Magnum/SceneGraph/Python.h(67): error C2614: 'Magnum::SceneGraph::PyObject<esp::scene::SceneNode>': illegal member initialization: 'Object' is not a base or member

**change to magnum.cpp fixes:**
magnum-bindings\src\python\magnum\magnum.cpp(220): error C2375: 'PyInit__magnum': redefinition; different linkage

**change to glfw.cpp fixes:**
magnum-bindings\src\python\magnum\platform\glfw.cpp(44): error C3640: 'magnum::platform::glfw::PublicizedApplication::[thunk]: __thiscall `void __cdecl magnum::platform::glfw(pybind11::module &)'::`2'::PublicizedApplication::`vcall'{8,{flat}}' }'': a referenced or virtual member function of a local class must be defined

