### PR TITLE
Code coverage on AppVeyor

### DIFF
--- a/package/ci/appveyor-desktop-gles.bat
+++ b/package/ci/appveyor-desktop-gles.bat
@@ -96,6 +96,14 @@ rem python -m doctest -v *.rst || exit /b
 rem Upload coverage
 cd ../../src/python || exit /b
 coverage combine || exit /b
-rem TODO: Currently disabled because I can't seem to convince it to relocate
-rem the paths via codecov.yml: https://github.com/mosra/magnum-bindings/pull/3
-rem codecov -X gcov || exit /b
+
+rem I am unable to convince codecov to relocate paths using codecov.yml so
+rem let's do that manually. But that doesn't work either.
+powershell -Command "(gc .coverage) -replace 'C:\\\\projects\\\\magnum-bindings\\\\build\\\\src\\\\python\\\\', 'C:\\projects\\magnum-bindings\\src\\python\\' | Out-File -encoding ASCII .coverage" || exit /b
+del ..\..\build\src\python\corrade\__init__.py || exit /b
+del ..\..\build\src\python\magnum\__init__.py || exit /b
+del ..\..\build\src\python\magnum\platform\__init__.py || exit /b
+
+codecov -X gcov || exit /b
+
+type coverage.xml

--- a/package/ci/appveyor-desktop-gles.bat
+++ b/package/ci/appveyor-desktop-gles.bat
@@ -100,10 +100,14 @@ coverage combine || exit /b
 rem I am unable to convince codecov to relocate paths using codecov.yml so
 rem let's do that manually. But that doesn't work either.
 powershell -Command "(gc .coverage) -replace 'C:\\\\projects\\\\magnum-bindings\\\\build\\\\src\\\\python\\\\', 'C:\\projects\\magnum-bindings\\src\\python\\' | Out-File -encoding ASCII .coverage" || exit /b
+
+type .coverage
+
 del ..\..\build\src\python\corrade\__init__.py || exit /b
 del ..\..\build\src\python\magnum\__init__.py || exit /b
 del ..\..\build\src\python\magnum\platform\__init__.py || exit /b
 
+cd ..\..
 codecov -X gcov || exit /b
 
 type coverage.xml

--- a/package/ci/appveyor-desktop.bat
+++ b/package/ci/appveyor-desktop.bat
@@ -97,6 +97,14 @@ rem python -m doctest -v *.rst || exit /b
 rem Upload coverage
 cd ../../src/python || exit /b
 coverage combine || exit /b
-rem TODO: Currently disabled because I can't seem to convince it to relocate
-rem the paths via codecov.yml: https://github.com/mosra/magnum-bindings/pull/3
-rem codecov -X gcov || exit /b
+
+rem I am unable to convince codecov to relocate paths using codecov.yml so
+rem let's do that manually. But that doesn't work either.
+powershell -Command "(gc .coverage) -replace 'C:\\\\projects\\\\magnum-bindings\\\\build\\\\src\\\\python\\\\', 'C:\\projects\\magnum-bindings\\src\\python\\' | Out-File -encoding ASCII .coverage" || exit /b
+del ..\..\build\src\python\corrade\__init__.py || exit /b
+del ..\..\build\src\python\magnum\__init__.py || exit /b
+del ..\..\build\src\python\magnum\platform\__init__.py || exit /b
+
+codecov -X gcov || exit /b
+
+type coverage.xml

--- a/package/ci/appveyor-desktop.bat
+++ b/package/ci/appveyor-desktop.bat
@@ -101,10 +101,14 @@ coverage combine || exit /b
 rem I am unable to convince codecov to relocate paths using codecov.yml so
 rem let's do that manually. But that doesn't work either.
 powershell -Command "(gc .coverage) -replace 'C:\\\\projects\\\\magnum-bindings\\\\build\\\\src\\\\python\\\\', 'C:\\projects\\magnum-bindings\\src\\python\\' | Out-File -encoding ASCII .coverage" || exit /b
+
+type .coverage
+
 del ..\..\build\src\python\corrade\__init__.py || exit /b
 del ..\..\build\src\python\magnum\__init__.py || exit /b
 del ..\..\build\src\python\magnum\platform\__init__.py || exit /b
 
+cd ..\..
 codecov -X gcov || exit /b
 
 type coverage.xml


### PR DESCRIPTION
I don't know. It just *insists* on putting the `__init__.py` files where they shouldn't be (there's `corrade/__init__.py` *in the root of the project* for no reason). This works flawlessly on Travis, one entry per system in `package/ci/codecov.yml` is enough there. Even doing a find&replace on the JSON `.coverage` files doesn't help, the XML always ends up having those relative again.

I don't want to merge this because it makes the coverage report extremely messy. Not that codecov wouldn't be mostly broken anyway tho.

Ugh.