### PR TITLE
Don't error if path is already fullpath

### DIFF
--- a/src/python/setup.py.cmake
+++ b/src/python/setup.py.cmake
@@ -60,7 +60,10 @@ if '${MAGNUM_BUILD_STATIC}' != 'ON':
 class TheExtensionIsAlreadyBuiltWhyThisHasToBeSoDamnComplicated(build_ext):
     def run(self):
         for ext in self.extensions:
-            shutil.copyfile(extension_paths[ext.name], self.get_ext_fullpath(ext.name))
+            try:
+                shutil.copyfile(extension_paths[ext.name], self.get_ext_fullpath(ext.name))
+            except shutil.SameFileError:
+                pass
 
 setup(
     name='magnum',


### PR DESCRIPTION
copyfile raises a SameFileError if the source and destination are the same. In this case, the error should be ignored.