### PR TITLE
Framebuffer texture support

### DIFF
--- a/src/python/magnum/gl.cpp
+++ b/src/python/magnum/gl.cpp
@@ -911,7 +911,13 @@ void gl(py::module_& m) {
                before the framebuffer */
             pyObjectHolderFor<GL::PyFramebufferHolder>(self).attachments.emplace_back(pyObjectFromInstance(renderbuffer));
         }, "Attach renderbuffer to given buffer")
+        .def("attach_texture", [](GL::Framebuffer& self, GL::Framebuffer::BufferAttachment attachment, GL::Texture2D& texture, Int level) {
+            self.attachTexture(attachment, texture, level);
 
+            /* Keep a reference to the texture to avoid it being deleted
+               before the framebuffer */
+            pyObjectHolderFor<GL::PyFramebufferHolder>(self).attachments.emplace_back(pyObjectFromInstance(texture));
+        }, "Attach texture to given buffer")
         .def_property_readonly("attachments", [](GL::Framebuffer& self) {
             return pyObjectHolderFor<GL::PyFramebufferHolder>(self).attachments;
         }, "Renderbuffer and texture objects referenced by the framebuffer");

--- a/src/python/magnum/gl.cpp
+++ b/src/python/magnum/gl.cpp
@@ -1301,6 +1301,16 @@ void gl(py::module_& m) {
         #ifndef MAGNUM_TARGET_GLES
         .value("RGBA12", GL::TextureFormat::RGBA12)
         #endif
+        #if !(defined(MAGNUM_TARGET_WEBGL) && defined(MAGNUM_TARGET_GLES2))
+        .value("DEPTH_COMPONENT16", GL::TextureFormat::DepthComponent16)
+        .value("DEPTH_COMPONENT24", GL::TextureFormat::DepthComponent24)
+        #endif
+        #ifndef MAGNUM_TARGET_WEBGL
+        .value("DEPTH_COMPONENT32", GL::TextureFormat::DepthComponent32)
+        #endif
+        #ifndef MAGNUM_TARGET_GLES2
+        .value("DEPTH_COMPONENT32F", GL::TextureFormat::DepthComponent32F)
+        #endif
         ;
         /** @todo compressed formats */
 


### PR DESCRIPTION
I want to be able to attach textures to framebuffers and of course read/write to them. This PR exposes the attach_texture method and depth component enums. I think we would also need to add map_for* overload(s?) in order to be able to read the depth component of a texture. I'm not quite sure on the map_for* overloads, perhaps you could suggest?