### PR TITLE
Minor clang-tidy fixups in some of the "next" magnum-bindings

### DIFF
--- a/src/python/magnum/gl.cpp
+++ b/src/python/magnum/gl.cpp
@@ -364,10 +364,10 @@ void gl(py::module_& m) {
         corrade::enumOperators(contextDetectedDriver);
 
         context
-            .def_property_readonly_static("has_current", [](py::object) {
+            .def_property_readonly_static("has_current", [](const py::object&) {
                 return GL::Context::hasCurrent();
             }, "Whether there is any current context")
-            .def_property_readonly_static("current", [](py::object) {
+            .def_property_readonly_static("current", [](const py::object&) {
                 if(!GL::Context::hasCurrent()) {
                     PyErr_SetString(PyExc_RuntimeError, "no current context");
                     throw py::error_already_set{};
@@ -901,7 +901,7 @@ void gl(py::module_& m) {
         .def(py::init<MeshPrimitive>(), "Constructor", py::arg("primitive"))
         .def_property_readonly("id", &GL::Mesh::id, "OpenGL vertex array ID")
         .def_property("primitive", &GL::Mesh::primitive,
-            [](GL::Mesh& self, py::object primitive) {
+            [](GL::Mesh& self, const py::object &primitive) {
                 if(py::isinstance<MeshPrimitive>(primitive))
                     self.setPrimitive(py::cast<MeshPrimitive>(primitive));
                 else if(py::isinstance<GL::MeshPrimitive>(primitive))
@@ -1100,10 +1100,10 @@ void gl(py::module_& m) {
             #endif
 
             /** @todo FFS why do I have to pass the class as first argument?! */
-            .def_property_static("clear_color", nullptr, [](py::object, const Color4& color) {
+            .def_property_static("clear_color", nullptr, [](const py::object&, const Color4& color) {
                 GL::Renderer::setClearColor(color);
             }, "Set clear color")
-            .def_property_readonly_static("error", [](py::object) {
+            .def_property_readonly_static("error", [](const py::object&) {
                 return GL::Renderer::error();
             }, "Error status");
     }

--- a/src/python/magnum/platform/cgl.cpp
+++ b/src/python/magnum/platform/cgl.cpp
@@ -63,7 +63,7 @@ void cgl(py::module_& m) {
 
         /* The base doesn't have a virtual destructor because in C++ it's never
            deleted through a pointer to the base. Here we need it, though. */
-        virtual ~PyWindowlessApplication() {}
+        virtual ~PyWindowlessApplication() = default;
     };
 
     py::class_<PyWindowlessApplication, ApplicationHolder<PyWindowlessApplication>> windowlessGlxApplication{m, "WindowlessApplication", "Windowless CGL application"};

--- a/src/python/magnum/platform/egl.cpp
+++ b/src/python/magnum/platform/egl.cpp
@@ -63,7 +63,7 @@ void egl(py::module_& m) {
 
         /* The base doesn't have a virtual destructor because in C++ it's never
            deleted through a pointer to the base. Here we need it, though. */
-        virtual ~PyWindowlessApplication() {}
+        virtual ~PyWindowlessApplication() = default;
     };
 
     py::class_<PyWindowlessApplication, ApplicationHolder<PyWindowlessApplication>> windowlessEglApplication{m, "WindowlessApplication", "Windowless EGL application"};

--- a/src/python/magnum/platform/glfw.cpp
+++ b/src/python/magnum/platform/glfw.cpp
@@ -64,7 +64,7 @@ void glfw(py::module_& m) {
 
         /* The base doesn't have a virtual destructor because in C++ it's never
            deleted through a pointer to the base. Here we need it, though. */
-        virtual ~PublicizedApplication() {}
+        virtual ~PublicizedApplication() = default;
     };
 
     struct PyApplication: PublicizedApplication {

--- a/src/python/magnum/platform/glx.cpp
+++ b/src/python/magnum/platform/glx.cpp
@@ -63,7 +63,7 @@ void glx(py::module_& m) {
 
         /* The base doesn't have a virtual destructor because in C++ it's never
            deleted through a pointer to the base. Here we need it, though. */
-        virtual ~PyWindowlessApplication() {}
+        virtual ~PyWindowlessApplication() = default;
     };
 
     py::class_<PyWindowlessApplication, ApplicationHolder<PyWindowlessApplication>> windowlessGlxApplication{m, "WindowlessApplication", "Windowless GLX application"};

--- a/src/python/magnum/platform/wgl.cpp
+++ b/src/python/magnum/platform/wgl.cpp
@@ -63,7 +63,7 @@ void wgl(py::module_& m) {
 
         /* The base doesn't have a virtual destructor because in C++ it's never
            deleted through a pointer to the base. Here we need it, though. */
-        virtual ~PyWindowlessApplication() {}
+        virtual ~PyWindowlessApplication() = default;
     };
 
     py::class_<PyWindowlessApplication, ApplicationHolder<PyWindowlessApplication>> windowlessWglApplication{m, "WindowlessApplication", "Windowless WGL application"};


### PR DESCRIPTION
Apply some minor perf/correctness improvement to the next-bindings:
* Don't pass by value unused variables
* Explicitly default empty virtual dtor constructors. This allows the optimizer to be more aggressive in optimizing them.