### PR TITLE
Py array holder missing move

### DIFF
--- a/src/Corrade/Containers/PythonBindings.h
+++ b/src/Corrade/Containers/PythonBindings.h
@@ -45,7 +45,7 @@ template<class T> struct PyArrayViewHolder: std::unique_ptr<T> {
 };
 
 template<class T> PyArrayViewHolder<T> pyArrayViewHolder(const T& view, pybind11::object owner) {
-    return PyArrayViewHolder<T>{new T{view}, owner};
+    return PyArrayViewHolder<T>{new T{view}, std::move(owner)};
 }
 
 }}


### PR DESCRIPTION
* Caught a missing std::move in one of the Python bindings when looking through them by hand. Prevents a useless incref / decref.