### PR TITLE
chore: remove extra copy in gl.cpp

### DIFF
--- a/src/python/magnum/gl.cpp
+++ b/src/python/magnum/gl.cpp
@@ -380,7 +380,7 @@ void gl(py::module_& m) {
                     owner = Corrade::pyObjectFromInstance(glContextOwner->first, *glContextOwner->second);
                 }
 
-                return ContextHolder<GL::Context>{&GL::Context::current(), owner};
+                return ContextHolder<GL::Context>{&GL::Context::current(), std::move(owner)};
             }, "Current context")
             /** @todo context switching (needs additions to the "who owns
                 current context instance" variable -- a map?) */


### PR DESCRIPTION
I was looking at the python bindings and noticed a perf bug. The reference count of owner in this context is unnecessarily increased, by using std::move we can just steal the reference instead.